### PR TITLE
Added support for MG_ENABLE_THREADSAFE_MBUF

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1968,6 +1968,10 @@ struct mbuf {
   char *buf;   /* Buffer pointer */
   size_t len;  /* Data length. Data is located between offset 0 and len. */
   size_t size; /* Buffer size allocated by realloc(1). Must be >= len */
+
+#if MG_ENABLE_THREADSAFE_MBUF
+  pthread_mutex_t mutex;
+#endif
 };
 
 /*


### PR DESCRIPTION
When we are dealing with multithreaded requests/responses in our
mongoose-cpp, as described in:

https://github.com/cesanta/mongoose/issues/758